### PR TITLE
Explicitly call toString() on Uint8Array

### DIFF
--- a/shell-volume-mixer@derhofbauer.at/utils.js
+++ b/shell-volume-mixer@derhofbauer.at/utils.js
@@ -8,6 +8,7 @@
 
 /* exported getCards, l, d, error, repeatString, getExtensionPath, versionGreaterOrEqual */
 
+const ByteArray = imports.byteArray;
 const Config = imports.misc.config;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const GLib = imports.gi.GLib;
@@ -95,6 +96,9 @@ function getCards() {
 
     let ret = null;
     try {
+        if (output instanceOf Uint8Array) {
+            output = ByteArray.toString(output);
+        }
         ret = JSON.parse(output);
     } catch (e) {
         error('utils', 'getCards', e.message);


### PR DESCRIPTION
Correction based on warning given with gnome shell 3.30:
"Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array)."