### PR TITLE
Missing files from lib when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SOURCES = \
 	locale/*/*/*.mo \
 	pautils/cardinfo.py \
 	pautils/pa.py \
-	lib/*.js \
+	lib/* \
 	*.js \
 	prefs.ui \
 	stylesheet.css \


### PR DESCRIPTION
When building from source, it was saying that the module "Menu" couldn't be found. It's just not imported in the make file because it's in a directory.

Thanks for the cool extension and fixing it for gnome 3.32!  :+1: :)