### PR TITLE
Connect to "changed" instead of "changed::"

### DIFF
--- a/shell-volume-mixer@derhofbauer.at/lib/settings.js
+++ b/shell-volume-mixer@derhofbauer.at/lib/settings.js
@@ -137,7 +137,7 @@ var Settings = class
      * @param callback
      */
     connectChanged(callback) {
-        this.connect('changed::', callback);
+        this.connect('changed', callback);
     }
 
     /**


### PR DESCRIPTION
Verified to fix #112 on GNOME 3.34.4, Arch Linux.
A big thank to verdre at #gnome-shell:gnome.org for helping.