### PR TITLE
Always hide input indicator

### DIFF
--- a/shell-volume-mixer@derhofbauer.at/lib/menu/menu.js
+++ b/shell-volume-mixer@derhofbauer.at/lib/menu/menu.js
@@ -175,6 +175,10 @@ var Menu = class extends VolumeMenuExtension
         return this._input.getIcon();
     }
 
+    getInputVisible() {
+        return false;
+    }
+
     _addSeparator() {
         if (this._separator) {
             this._separator.destroy();


### PR DESCRIPTION
This gets rid of unnecessary space between volume and power icon.