### PR TITLE
Make indicator consume scroll events

### DIFF
--- a/shell-volume-mixer@derhofbauer.at/lib/menu/indicator.js
+++ b/shell-volume-mixer@derhofbauer.at/lib/menu/indicator.js
@@ -44,14 +44,10 @@ var Indicator = GObject.registerClass(class Indicator extends PanelMenu.SystemIn
         this._primaryIndicator.reactive = true;
         this._inputIndicator.reactive = true;
 
-        this._primaryIndicator.connect('scroll-event', (actor, event) => {
-            Volume.Indicator.prototype._handleScrollEvent.apply(this, [VolumeType.OUTPUT, event]);
-            return true;
-        });
-        this._inputIndicator.connect('scroll-event', (actor, event) => {
-            Volume.Indicator.prototype._handleScrollEvent.apply(this, [VolumeType.INPUT, event]);
-            return true;
-        });
+        this._primaryIndicator.connect('scroll-event',
+            (actor, event) => Volume.Indicator.prototype._handleScrollEvent.apply(this, [VolumeType.OUTPUT, event]));
+        this._inputIndicator.connect('scroll-event',
+            (actor, event) => Volume.Indicator.prototype._handleScrollEvent.apply(this, [VolumeType.INPUT, event]));
 
         this._control = mixer.control;
         this._volumeMenu = new Menu(mixer, options);

--- a/shell-volume-mixer@derhofbauer.at/lib/widget/volume.js
+++ b/shell-volume-mixer@derhofbauer.at/lib/widget/volume.js
@@ -291,11 +291,13 @@ var MasterSlider = class extends StreamSlider
     }
 
     scroll(event) {
-        super.scroll(event);
+        const eventResult = super.scroll(event);
 
         if (Main.panel.statusArea.aggregateMenu.menu.isOpen) {
             this._showVolumeInfo();
         }
+
+        return eventResult;
     }
 };
 


### PR DESCRIPTION
like original indicator does:
https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/status/volume.js#L65

It will keep other extensions which listen to bar scrolling from consuming events already recognized as volume adjusting one;
see https://github.com/mrEDitor/gnome-shell-extension-scroll-panel/issues/15