### PR TITLE
Declare compatibility with GNOME Shell 41

### DIFF
--- a/shell-volume-mixer@derhofbauer.at/metadata.json
+++ b/shell-volume-mixer@derhofbauer.at/metadata.json
@@ -4,7 +4,8 @@
     "name": "Volume Mixer",
     "description": "Applet allowing separate configuration of PulseAudio mixers.\n\nShell Volume Mixer is an extension for GNOME Shell allowing separate configuration of PulseAudio devices and output switches. It features a profile switcher to quickly switch between pinned profiles and devices.\n\nMiddle mouse click on a slider mutes the selected stream.\n\nPlease file bugs and feature requests on the GitHub page.",
     "shell-version": [
-        "40"
+        "40",
+        "41"
     ],
     "settings-schema": "org.gnome.shell.extensions.shell-volume-mixer",
     "gettext-domain": "gnome-shell-extensions-shell-volume-mixer",


### PR DESCRIPTION
Based on some brief testing, this extension seems to be compatible
without requiring further changes.

Resolves: https://github.com/aleho/gnome-shell-volume-mixer/issues/142