### PR TITLE
Add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Requirements
 ------------
 
 - PulseAudio (for retrieval of card details)
+- Python3 (for retrieval of card details)
 - gettext (for building of language files)
 - nodejs / npm (styles and linting)
 - glib2 bin (schema compilation)


### PR DESCRIPTION
Not all distros have `python3` installed by default. Would have saved me some time debugging.